### PR TITLE
[client] opengl: render frame if config didn't change

### DIFF
--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -564,6 +564,8 @@ bool opengl_render(void * opaque, SDL_Window * window)
       return false;
 
     case CONFIG_STATUS_NOOP :
+      break;
+
     case CONFIG_STATUS_OK   :
      if (!draw_frame(this))
        return false;


### PR DESCRIPTION
This is @DataBeaver's OpenGL fix from https://github.com/gnif/LookingGlass/issues/248#issuecomment-613007471

> There seems to be a logic error in the OpenGL code. draw_frame() is only called if configure() returns CONFIG_STATUS_OK. However if a reconfigure wasn't needed it will return CONFIG_STATUS_NOOP and only the mouse pointer will be rendered. With this patch the OpenGL renderer will update correctly: http://www.tdb.fi/~tdb/tmp/0001-client-render-frame-if-config-didn-t-change.patch